### PR TITLE
Use push-jobs cookbook

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -14,4 +14,10 @@
 # limitations under the License.
 #
 
-default['delivery-base']['push-client']['version'] = nil
+include_attribute 'push-jobs'
+
+case node['platform_family']
+when 'windows'
+  default['push_jobs']['package_url']      = 'https://opscode-private-chef.s3.amazonaws.com/windows/2008r2/x86_64/opscode-push-jobs-client-windows-1.1.5-1.windows.msi'
+  default['push_jobs']['package_checksum'] = '411520e6a2e3038cd018ffacee0e76e37e7badd1aa84de03f5469c19e8d6c576'
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Delivery base cookbook'
 long_description 'Sets up the base things for a node to be use in Chef Delivery'
 
-version '0.2.0'
+version '0.2.1'
 
 source_url 'https://github.com/chef-cookbooks/delivery-base'
 issues_url 'https://github.com/chef-cookbooks/delivery-base/issues'
@@ -15,4 +15,4 @@ supports 'redhat', '>= 6.5'
 supports 'centos', '>= 6.5'
 supports 'windows'
 
-depends 'chef-ingredient'
+depends 'push-jobs'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -14,7 +14,4 @@
 # limitations under the License.
 #
 
-chef_ingredient 'push-client' do
-  version node['delivery-base']['push-client']['version']
-  action :install
-end
+include_recipe 'push-jobs'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -17,8 +17,8 @@ describe 'delivery-base::default' do
       expect { chef_run }.to_not raise_error
     end
 
-    it 'installs chef ingredient push-client' do
-      expect(chef_run).to install_chef_ingredient 'push-client'
+    it 'depends on push-jobs' do
+      expect(chef_run).to include_recipe 'push-jobs'
     end
   end
 


### PR DESCRIPTION
The `push-jobs` cookbook does more than just install push-client package. It configure it and also install `runit` to be able to start and stop the service. 

This change puts back the dependency with `push-jobs` but deletes the packages url for *nix systems so we use `chef_ingredient`. For windows we still need the package url/checksum.
